### PR TITLE
RATIS-1167. Fix the link to raft main page

### DIFF
--- a/content/getting_started.md
+++ b/content/getting_started.md
@@ -15,7 +15,7 @@ title: Getting started
   limitations under the License. See accompanying LICENSE file.
 -->
 
-Ratis is a [Raft](https://raft.github.io/") protocol *library* in Java. It's not a standalone server application like Zookeeper or Consul.
+Ratis is a [Raft](https://raft.github.io/) protocol *library* in Java. It's not a standalone server application like Zookeeper or Consul.
 
 ### Examples
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the redundant " in link to Raft page.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1167

## How was this patch tested?

IMHO it is a minor change, and we don't need test.
